### PR TITLE
Renamed passed parameter name for Merchant ID in the `Transaction::create()` example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $privateAppKey = 'your-private-key-goes-here';
                     'amount'   => $amount,      //value must be in cents 
                     'currency' => $currency     //see available formats https://github.com/paylike/currencies
                 );
-     $transaction = \Paylike\Transaction::create( $transactionId, $data );
+     $transaction = \Paylike\Transaction::create( $merchantId, $data );
 	// you will now have the transaction data in the $transaction variable.
 ```
 


### PR DESCRIPTION
I went ahead and renamed the `$merchantId` parameter passed to the documented `Transaction::create()` call to `$transactionId`. As the `create()` method accepts a merchant ID and not a transaction ID.

This should help prevent some confusion for users reviewing the docs for the `Transaction::create()` method. 😄 