### PR TITLE
Fix the bug with wrong message parsing

### DIFF
--- a/src/HttpClient/CurlClient.php
+++ b/src/HttpClient/CurlClient.php
@@ -221,11 +221,11 @@ class CurlClient implements HttpClientInterface
                 // - [{"code":2,"text":"Invalid card details", "client": true, "merchant": false}]
                 $message = "Bad (invalid) request";
                 // @TODO - extract error parsing logic
-                if ($json_resp && is_array($json_resp) && ! empty($json_resp)) {
-                    if (isset($json_resp[0]['message'])) {
-                        $message = $json_resp[0]['message'];
-                    } else if (isset($json_resp[0]['text'])) {
-                        $message = $json_resp[0]['text'];
+                if ($json_resp && is_array($json_resp)) {
+                    if (isset($json_resp['message'])) {
+                        $message = $json_resp['message'];
+                    } else if (isset($json_resp['text'])) {
+                        $message = $json_resp['text'];
                     }
                 }
                 throw new InvalidRequest($message,

--- a/src/HttpClient/CurlClient.php
+++ b/src/HttpClient/CurlClient.php
@@ -217,8 +217,8 @@ class CurlClient implements HttpClientInterface
         switch ($response_code) {
             case 400:
                 // format for the errors:
-                // - [{"field":"amount","message":"Can refund at most GBP 0"}]
-                // - [{"code":2,"text":"Invalid card details", "client": true, "merchant": false}]
+                // - {"field":"amount","message":"Can refund at most GBP 0"}
+                // - {"code":2,"text":"Invalid card details", "client": true, "merchant": false}
                 $message = "Bad (invalid) request";
                 // @TODO - extract error parsing logic
                 if ($json_resp && is_array($json_resp)) {


### PR DESCRIPTION
There is mentioned API response which is wrong:
```
                // format for the errors:
                // - [{"field":"amount","message":"Can refund at most GBP 0"}]
                // - [{"code":2,"text":"Invalid card details", "client": true, "merchant": false}]
```

It is not a multi-array. This commit fixes that bug.