### PR TITLE
Refactored to replace the resource soft reserved word

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "paylike/php-api",
   "description": "PHP SDK to communicate with the Paylike HTTP api",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MIT",
   "authors": [
     {

--- a/init.php
+++ b/init.php
@@ -8,12 +8,12 @@ require(dirname(__FILE__) . '/src/Exception/InvalidRequest.php');
 require(dirname(__FILE__) . '/src/Exception/NotFound.php');
 require(dirname(__FILE__) . '/src/Exception/Unauthorized.php');
 
-// Resource
-require(dirname(__FILE__) . '/src/Resource/Resource.php');
-require(dirname(__FILE__) . '/src/Resource/Apps.php');
-require(dirname(__FILE__) . '/src/Resource/Merchants.php');
-require(dirname(__FILE__) . '/src/Resource/Transactions.php');
-require(dirname(__FILE__) . '/src/Resource/Cards.php');
+// Endpoint
+require( dirname( __FILE__ ) . '/src/Endpoint/Endpoint.php' );
+require( dirname( __FILE__ ) . '/src/Endpoint/Apps.php' );
+require( dirname( __FILE__ ) . '/src/Endpoint/Merchants.php' );
+require( dirname( __FILE__ ) . '/src/Endpoint/Transactions.php' );
+require( dirname( __FILE__ ) . '/src/Endpoint/Cards.php' );
 
 // Response
 require(dirname(__FILE__) . '/src/Response/ApiResponse.php');

--- a/src/Endpoint/Apps.php
+++ b/src/Endpoint/Apps.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Paylike\Resource;
+namespace Paylike\Endpoint;
 
 /**
  * Class Apps
  *
- * @package Paylike\Resource
+ * @package Paylike\Endpoint
  */
-class Apps extends Resource
+class Apps extends Endpoint
 {
     /**
      * @link https://github.com/paylike/api-docs#create-an-app

--- a/src/Endpoint/Cards.php
+++ b/src/Endpoint/Cards.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Paylike\Resource;
+namespace Paylike\Endpoint;
 
 /**
  * Class Cards
  *
- * @package Paylike\Resource
+ * @package Paylike\Endpoint
  */
-class Cards extends Resource
+class Cards extends Endpoint
 {
     /**
      * @link https://github.com/paylike/api-docs#save-a-card

--- a/src/Endpoint/Endpoint.php
+++ b/src/Endpoint/Endpoint.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Paylike\Resource;
+namespace Paylike\Endpoint;
 
 /**
- * Class Resource
+ * Class Endpoint
  *
- * @package Paylike\Resource
+ * @package Paylike\Endpoint
  */
-abstract class Resource
+abstract class Endpoint
 {
     /**
      * @var \Paylike\Paylike
@@ -15,7 +15,7 @@ abstract class Resource
     protected $paylike;
 
     /**
-     * Resource constructor.
+     * Endpoint constructor.
      *
      * @param $paylike
      */

--- a/src/Endpoint/Merchants.php
+++ b/src/Endpoint/Merchants.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Paylike\Resource;
+namespace Paylike\Endpoint;
 
 use Paylike\Utils\Cursor;
 
 /**
  * Class Merchants
  *
- * @package Paylike\Resource
+ * @package Paylike\Endpoint
  */
-class Merchants extends Resource
+class Merchants extends Endpoint
 {
     /**
      * @link https://github.com/paylike/api-docs#create-a-merchant

--- a/src/Endpoint/Transactions.php
+++ b/src/Endpoint/Transactions.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Paylike\Resource;
+namespace Paylike\Endpoint;
 
 use Paylike\Utils\Cursor;
 
 /**
  * Class Transactions
  *
- * @package Paylike\Resource
+ * @package Paylike\Endpoint
  */
-class Transactions extends Resource
+class Transactions extends Endpoint
 {
     /**
      * @link https://github.com/paylike/api-docs#create-a-transaction

--- a/src/HttpClient/CurlClient.php
+++ b/src/HttpClient/CurlClient.php
@@ -242,7 +242,7 @@ class CurlClient implements HttpClientInterface
                     $json_resp,
                     $response_headers);
             case 404:
-                throw new NotFound("Resource not found.",
+                throw new NotFound("Endpoint not found.",
                     $response_code, $response_body,
                     $json_resp,
                     $response_headers);

--- a/src/Paylike.php
+++ b/src/Paylike.php
@@ -4,10 +4,10 @@ namespace Paylike;
 
 use Paylike\HttpClient\HttpClientInterface;
 use Paylike\HttpClient\CurlClient;
-use Paylike\Resource\Apps;
-use Paylike\Resource\Merchants;
-use Paylike\Resource\Transactions;
-use Paylike\Resource\Cards;
+use Paylike\Endpoint\Apps;
+use Paylike\Endpoint\Merchants;
+use Paylike\Endpoint\Transactions;
+use Paylike\Endpoint\Cards;
 
 /**
  * Class Paylike

--- a/tests/AppsTest.php
+++ b/tests/AppsTest.php
@@ -2,7 +2,7 @@
 
 namespace Paylike\Tests;
 
-use Paylike\Resource\Apps;
+use Paylike\Endpoint\Apps;
 
 class AppsTest extends BaseTest
 {

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -19,7 +19,7 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
     {
         $this->paylike        = new Paylike("dbcf01af-8667-4967-9791-56101ca87ac8");
         $this->app_id         = "594d3cde5be12d547cbe2ec2";
-        $this->transaction_id = "594d3d2cbe4728547d40150e";
+        $this->transaction_id = "5da8272132aad22568a511b7";
         $this->merchant_id    = "594d3c455be12d547cbe2ebe";
     }
 }

--- a/tests/CardsTest.php
+++ b/tests/CardsTest.php
@@ -3,7 +3,7 @@
 namespace Paylike\Tests;
 
 use Paylike\Exception\NotFound;
-use Paylike\Resource\Cards;
+use Paylike\Endpoint\Cards;
 
 class CardsTest extends BaseTest
 {

--- a/tests/CurrenciesTest.php
+++ b/tests/CurrenciesTest.php
@@ -5,7 +5,7 @@ namespace Paylike\Tests;
 use Paylike\Data\Currencies;
 use Paylike\Exception\NotFound;
 
-class CardsTest extends BaseTest {
+class CurrenciesTest extends BaseTest {
 	/**
 	 * @var Currencies
 	 */

--- a/tests/MerchantsTest.php
+++ b/tests/MerchantsTest.php
@@ -2,7 +2,7 @@
 
 namespace Paylike\Tests;
 
-use Paylike\Resource\Merchants;
+use Paylike\Endpoint\Merchants;
 
 class MerchantsTest extends BaseTest
 {

--- a/tests/TransactionsTest.php
+++ b/tests/TransactionsTest.php
@@ -4,7 +4,7 @@ namespace Paylike\Tests;
 
 use Paylike\Exception\InvalidRequest;
 use Paylike\Exception\NotFound;
-use Paylike\Resource\Transactions;
+use Paylike\Endpoint\Transactions;
 
 class TransactionsTest extends BaseTest
 {


### PR DESCRIPTION
PHP introduced `resource` as a soft reserved word. To avoid problems refactoring has been done.
https://www.php.net/manual/en/reserved.other-reserved-words.php